### PR TITLE
Mention -Y flag for yarn users

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ sb-create
 
 This will create `sb` folder with all dependencies based on project type.
 
+Add the `-Y` or `--use-yarn` flag if your project uses yarn instead of npm as package manager. 
+
 ## Usage
 #### Available commands
 ```bash


### PR DESCRIPTION
When I ran `sb-create` in my project, I always got this error. After debugging, I noticed that sb-create did not recognize that my project uses yarn properly. Passing the -Y flag fixed the issue. I think it'd be beneficial to make mention of this flag. 
 
```
 Error: spawnSync npm.cmd ENOENT
    at _errnoException (util.js:1024:11)
    at spawnSync (child_process.js:579:20)
    at exports.installDeps (/usr/local/lib/node_modules/sb-cli/lib/helpers.js:100:14)
    at Object.<anonymous> (/usr/local/lib/node_modules/sb-cli/bin/generate.js:66:5)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Function.Module.runMain (module.js:676:10)
. ✖

     An error occured while installing dependencies`.
```